### PR TITLE
UDP Server Created.

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2024 Luka Piplica piplicaluka64@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+	"net"
+
+	"program/dns-forward/error"
+
+	"github.com/spf13/cobra"
+)
+
+// startCmd represents the start command
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start a UDP server.",
+	Long: `The start commands starts a UDP server.
+		By default the server starts on port 8080.
+		i.e
+		dns-forwarder start
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Starting UDP server...")
+		var port int = 8080
+
+		// Creating a UDP address to listen on all available network interfaces
+		addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", port))
+		error.Check(err)
+
+		// Creating a UDP listener
+		conn, err := net.ListenUDP("udp", addr)
+		error.Check(err)
+		// Close the UDP server once Run in finished executing
+		defer conn.Close()
+
+		fmt.Printf("UDP server is listening on port %d\n", port)
+
+		// Buffer to hold incoming data
+		buffer := make([]byte, 1024)
+
+		for {
+			// Read data from the connection
+			n, clientAddr, err := conn.ReadFromUDP(buffer)
+			error.Check(err)
+
+			fmt.Printf("Received %d bytes from %s: %s\n", n, clientAddr, buffer[:n])
+
+			// Respond to the client
+			response := []byte("Hello from UDP server!")
+			_, err = conn.WriteToUDP(response, clientAddr)
+			error.Check(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2024 Luka Piplica piplicaluka64@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// stopCmd represents the stop command
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("stop called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stopCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// stopCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// stopCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/error/check.go
+++ b/error/check.go
@@ -1,0 +1,10 @@
+package error
+
+import "log"
+
+func Check(err error) {
+	if err != nil {
+
+		log.Fatalf("An error occured: %v", err)
+	}
+}


### PR DESCRIPTION
A UDP server is started with the `start` command. The server is started on port 8080 and can read client messages.

i.e
* `dns-forward start`
* open another terminal window to test the UDP server using netcat
* `echo -n "Hello, UDP Server" | nc -u 127.0.0.1 8080`